### PR TITLE
docs: READMEにプロジェクトドキュメントサイトへのリンクを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 このプラグインは、MkDocsドキュメント内のMermaidダイアグラムを事前に静的画像（PNG/SVG）に変換し、ドキュメントビルド時に画像として埋め込むことで、PDF出力やオフライン表示を可能にします。
 
+- [Documents](https://thankful-beach-0f331f600.1.azurestaticapps.net/)
+
 ### 主な特徴
 
 - 🖼️ **静的画像変換**: MermaidダイアグラムをPNG/SVG画像として事前レンダリング


### PR DESCRIPTION
## Summary
- Azure Static Web AppsでホストされているプロジェクトドキュメントサイトへのリンクをREADME.mdに追加
- 概要セクションに配置し、ユーザーが詳細なドキュメントにアクセスしやすくなりました

## Changes
- README.md の概要セクションにドキュメントサイトのリンクを追加

## Test plan
- [x] make check-allが成功することを確認
- [x] READMEファイルの変更内容が適切であることを確認
- [x] ドキュメントリンクが正常に機能することを確認

## Impact
- ユーザーエクスペリエンスの向上: プロジェクトの詳細な使用方法や設定について包括的な情報に簡単にアクセス可能
- プロジェクトの可視性向上: ホストされたドキュメントサイトへの導線強化

🤖 Generated with [Claude Code](https://claude.ai/code)